### PR TITLE
use version number instead of release in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
   - osx
 julia:
   - 0.5
-  - release
+  - 0.6
 #  - nightly
 notifications:
   email: false


### PR DESCRIPTION
release will change over time, but your REQUIRE file says this package supports julia 0.5 so it should continue to be tested